### PR TITLE
Use precompiled qhc for help

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ bin/assistant*
 *.exe
 *.log
 *.pyc
+build
 tmp
 out
 __pycache__

--- a/help/make.bat
+++ b/help/make.bat
@@ -50,6 +50,7 @@ if %ERRORLEVEL% neq 0 goto :eof
 echo.
 echo ***** Copy built help files to bin dir...
 copy %TARGET_DIR%\rezonator.qch %BIN_DIR%
+copy %TARGET_DIR%\rezonator.qhc %BIN_DIR%
 if %ERRORLEVEL% neq 0 goto :eof
 
 
@@ -73,7 +74,7 @@ echo Assistant path is %HELP_TOOL_DIR%
 echo.
 echo ***** Running Assistant...
 cd %HELP_TOOL_DIR%
-assistant -collectionFile %TARGET_DIR%\rezonator.qhc -style fusion
+assistant -collectionFile %BIN_DIR%\rezonator.qhc -style fusion
 
 
 echo.

--- a/help/make.sh
+++ b/help/make.sh
@@ -34,6 +34,7 @@ build_help_files() {
 
   print_header "Copy built help files to bin dir..."
   cp ${TARGET_DIR}/rezonator.qch ${BIN_DIR}
+  cp ${TARGET_DIR}/rezonator.qhc ${BIN_DIR}
   exit_if_fail
 }
 
@@ -80,7 +81,7 @@ prepare_assistant() {
 
 run_assistant() {
   print_header "Running Assistant..."
-  ${ASSISTANT_TARGET} -collectionFile ${TARGET_DIR}/rezonator.qhc -style fusion
+  ${ASSISTANT_TARGET} -collectionFile ${BIN_DIR}/rezonator.qhc -style fusion
 }
 
 

--- a/release/make_package.py
+++ b/release/make_package.py
@@ -44,6 +44,7 @@ def make_package_for_windows():
   print_header('Copy project files...')
   copy_file('..\\..\\bin\\' + PROJECT_EXE, '.')
   copy_file('..\\..\\bin\\rezonator.qch', '.')
+  copy_file('..\\..\\bin\\rezonator.qhc', '.')
   shutil.copytree('..\\..\\bin\\examples', 'examples')
 
   print_header('Pack files to zip...')
@@ -65,6 +66,7 @@ def make_package_for_linux():
   print_header('Copy project files...')
   copy_file('../../bin/' + PROJECT_EXE, 'usr/bin')
   copy_file('../../bin/rezonator.qch', 'usr/bin')
+  copy_file('../../bin/rezonator.qhc', 'usr/bin')
   shutil.copytree('../../bin/examples', 'usr/bin/examples')
   copy_file(f'../../release/{PROJECT_NAME}.desktop', 'usr/share/applications')
   shutil.copyfile('../../img/icon/main_2_256.png', f'usr/share/icons/hicolor/256x256/apps/{PROJECT_NAME}.png')
@@ -107,6 +109,8 @@ def make_package_for_linux():
 def make_package_for_macos():
   print_header('Copy application bundle...')
   remove_dir(PROJECT_EXE)
+  # QCH and QHC help files are already in the bundle dir
+  # This is done during help compilation (see help/make.sh)
   shutil.copytree('../../bin/' + PROJECT_EXE, PROJECT_EXE)
 
   print_header('Run macdeployqt...')

--- a/src/windows/HelpWindow.h
+++ b/src/windows/HelpWindow.h
@@ -19,7 +19,7 @@ public:
     static void showTopic(const QString& topic);
 
 private:
-    static void openWindow();
+    static bool openWindow();
 
     explicit HelpWindow(QHelpEngine *engine);
     ~HelpWindow();


### PR DESCRIPTION
Qt6 can't create QHC file properly, it creates an empty file and then we have:

> Cannot register namespace \"org.orion-project.rezonator\".

Qt5 works fine and creates a proper file.

Bundle a QHC file created during help compilation and use it instead of allowing the help engine to create a new (probably currupted) one